### PR TITLE
abort if profile doesn't exist

### DIFF
--- a/server/resolver.py
+++ b/server/resolver.py
@@ -156,8 +156,7 @@ def get_user_profile(username):
         profile = full_profile_mem(key)
 
         if not profile:
-            #abort(404)
-            print "abort"
+            abort(404)
         else:
             info['profile'] = profile
             info['verifications'] = profile_to_proofs(profile, username)


### PR DESCRIPTION
What looks like debugging code was causing usernames that don't exist to return with status code 200 and an empty JSON object `{}`

![screen shot 2015-04-03 at 4 42 09 am](https://cloud.githubusercontent.com/assets/597182/6973256/13000890-d9bc-11e4-912a-9cb57b3c3932.png)
